### PR TITLE
Fix MV inputs throwing CPP error

### DIFF
--- a/R/samplers.R
+++ b/R/samplers.R
@@ -34,6 +34,7 @@
     }
   }
 }
+
 .checkNamesMatchParams <- function(distr_name, distr_params){
 
   names_cont <- c(
@@ -75,17 +76,8 @@
   } else{
     stop(paste("Distribution", distr_name, "is not supported"))
   }
-
-
-
-  if(isValidParameters){
-    # if (length(start) == 1 && substr(returnString, 3, 4) == "mv"){
-    #   stop("Start is length 1 but distribution is multivariate")
-    # } else if (length(start) != 1 && substr(returnString, 3,4) == "uv"){
-    #   stop("Distribution is univariate but start is not length 1")
-    # }
-    return(c(d_uv, c_mv)) ## logical vector c(isDiscrete, isMultivariate)
-  } else{
+  
+  if(!isValidParameters){
     if (c_mv){
       stop(paste("Parameters given do not match distribution name given. For the", distr_name, "distribution,", parameters_cont_mv[match(distr_name, names_cont_mv)], "parameters are expected in a list"))
     } else if (!d_uv){
@@ -93,8 +85,11 @@
     } else{
       stop(paste("Parameters given do not match distribution name given. For the", distr_name, "distribution,", parameters_discr[match(distr_name, names_discr)], "parameters are expected in a vector"))
     }
+  } else{
+    if (c_mv) .checkMVInputs(distr_name, distr_params)
+    
+    return(c(d_uv, c_mv)) ## logical vector c(isDiscrete, isMultivariate)    
   }
-
 }
 
 .checkStart <- function(info, start_dim){

--- a/R/samplers.R
+++ b/R/samplers.R
@@ -1,3 +1,39 @@
+.checkMVInputs <- function(distr_name, distr_params){
+  if (distr_name == "mvnorm"){
+    checks <- c(is.vector(distr_params[[1]]), is.matrix(distr_params[[2]]))
+    if (!all(checks)){
+      error_msg <- "Distribution parameters are not specified properly. For the mvnorm distribution,\n"
+      if (!checks[1]){
+        error_msg <- paste(error_msg, "- the mean should be a vector\n")
+      }
+      if (!checks[2]){
+        error_msg <- paste(error_msg, "- the covariance should be a matrix")
+      }
+      stop(error_msg)
+    }
+  } else if (distr_name == "mvt"){
+    checks <- c(
+      is.vector(distr_params[[1]]), 
+      is.matrix(distr_params[[2]]), 
+      is.numeric(distr_params[[3]]) & 
+          !is.matrix(distr_params[[3]]) & 
+          length(distr_params[[3]]) == 1
+      )
+    if (!all(checks)){
+      error_msg <- "Distribution parameters are not specified properly. For the mvt distribution,\n"
+      if (!checks[1]){
+        error_msg <- paste(error_msg, "- the location should be a vector\n")
+      }
+      if (!checks[2]){
+        error_msg <- paste(error_msg, "- the scale should be a matrix\n")
+      }
+      if (!checks[3]){
+        error_msg <- paste(error_msg, "- the df should be a number")
+      }
+      stop(error_msg)
+    }
+  }
+}
 .checkNamesMatchParams <- function(distr_name, distr_params){
 
   names_cont <- c("unif", "norm","lnorm", "gamma", "beta", "nbeta", "chisq", "nchisq", "t", "nt", "f", "nf", "cauchy", "exp", "logis", "weibull",

--- a/R/samplers.R
+++ b/R/samplers.R
@@ -36,12 +36,18 @@
 }
 .checkNamesMatchParams <- function(distr_name, distr_params){
 
-  names_cont <- c("unif", "norm","lnorm", "gamma", "beta", "nbeta", "chisq", "nchisq", "t", "nt", "f", "nf", "cauchy", "exp", "logis", "weibull",
-                  "4beta", "lst", "truncnorm", "trunct", "trunclst", "triangular")
+  names_cont <- c(
+    "unif", "norm","lnorm", "gamma", "beta", "nbeta", "chisq", "nchisq", 
+    "t", "nt", "f", "nf", "cauchy", "exp", "logis", "weibull",
+    "4beta", "lst", "truncnorm", "trunct", "trunclst", "triangular"
+  )
 
   names_cont_mv <- c("mvnorm", "mvt")
 
-  names_discr <- c("binom", "nbinom", "nbinom_mu", "pois", "geom", "hyper", "wilcox", "signrank")
+  names_discr <- c(
+    "binom", "nbinom", "nbinom_mu", 
+    "pois", "geom", "hyper", "wilcox", "signrank"
+  )
 
   # possible distr parameters
   parameters_cont <- c(2, 2, 2, 2, 2, 3, 1, 2, 1, 2, 2, 3, 2, 1, 2, 2,
@@ -61,7 +67,9 @@
   if (c_uv){
     isValidParameters = parameters_cont[match(distr_name, names_cont)] == length(distr_params)
   } else if(c_mv){
-    isValidParameters = parameters_cont_mv[match(distr_name, names_cont_mv)] == length(distr_params) && is.list(distr_params)
+    isValidParameters = 
+      parameters_cont_mv[match(distr_name, names_cont_mv)] == length(distr_params) && 
+      is.list(distr_params)
   } else if (d_uv){
     isValidParameters = parameters_discr[match(distr_name, names_discr)] == length(distr_params)
   } else{

--- a/tests/testthat/test-samplers.R
+++ b/tests/testthat/test-samplers.R
@@ -35,14 +35,20 @@ test_that(".checkNamesMatchParams", {
     if (!(names[i] %in% names_cont_mv)){
       res <-.checkNamesMatchParams(names[i], rep(0, params[i]))
     } else{
-      res <-.checkNamesMatchParams(names[i], as.list(rep(0, params[i])))
-      
+      if (names[i] == "mvnorm"){
+        res <-.checkNamesMatchParams(
+          names[i], list(c(0,0), diag(2)))  
+      } else {
+        if (names[i] == "mvt"){
+          res <-.checkNamesMatchParams(
+            names[i], list(c(0,0), diag(2), 1))  
+        }
+      }
     }
     expect_true(all(res == c(d_uv, c_mv)))
   }
   
   expect_error(.checkNamesMatchParams("asld", 2))
-  expect_error(.checkNamesMatchParams("norm", rep(0, 3)))
   expect_error(.checkNamesMatchParams("norm", rep(0, 3)))
   expect_error(.checkNamesMatchParams("norm", list(rep(0, 2))))
 })

--- a/tests/testthat/test-samplers.R
+++ b/tests/testthat/test-samplers.R
@@ -1,3 +1,18 @@
+test_that(".checkMVInputs", {
+  v <- c(0, 1)
+  m <- diag(2)
+  n <- 1
+  
+  expect_no_error(.checkMVInputs("mvnorm", list(v,m)))
+  expect_error(.checkMVInputs("mvnorm", list(v,v)))
+  expect_error(.checkMVInputs("mvnorm", list(m,m)))
+  
+  expect_no_error(.checkMVInputs("mvt", list(v,m,n)))
+  expect_error(.checkMVInputs("mvt", list(m,m,n)))
+  expect_error(.checkMVInputs("mvt", list(v,v,n)))
+  expect_error(.checkMVInputs("mvt", list(v,m,m)))
+})
+  
 test_that(".checkNamesMatchParams", {
   names_cont <- c("unif", "norm","lnorm", "gamma", "beta", "nbeta", "chisq", "nchisq", "t", "nt", "f", "nf", "cauchy", "exp", "logis", "weibull",
                   "4beta", "lst", "truncnorm", "trunct", "trunclst", "triangular")


### PR DESCRIPTION
Previously inputting the wrong data type to a mv distribution would throw an error in the cpp function - for example giving mvnorm a list of two vectors instead of a list(vector, matrix). Inputs are now checked so that the user is warned with a more comprehensible error message. 