### PR TITLE
Fix sigma prop input

### DIFF
--- a/R/samplers.R
+++ b/R/samplers.R
@@ -133,9 +133,24 @@
     # give it the arbitrary value of the identity matrix
     return(diag(n_dim))
   } else{
+    # If the user gave a number for a univariate distribution we convert it to a 1x1 matrix
     if (!is.matrix(sigma_prop) && length(sigma_prop) == 1 && n_dim == 1){
       return(matrix(sigma_prop))
+    # Otherwise we check for several possible errors
+    } else if (!is.matrix(sigma_prop)){
+      stop("Please provide a square matrix for the sigma_prop parameter.")
+    } else if ((nrow(sigma_prop) != ncol(sigma_prop))){
+      stop("Please provide a square matrix for the sigma_prop parameter.")
+    } else if (n_dim > 1){
+      if (nrow(sigma_prop) != n_dim){
+        stop(paste(
+          "The dimensions of the sigma_prop parameter must correspond to the size of the target distribution.\n",
+          "At the moment the sigma_prop matrix is ", nrow(sigma_prop)," by ", nrow(sigma_prop),
+          ", but the distribution is ", n_dim,"-dimensional.", sep=""
+        ))
+      }
     }
+    
     return(sigma_prop)
   }
 }

--- a/R/samplers.R
+++ b/R/samplers.R
@@ -137,9 +137,7 @@
     if (!is.matrix(sigma_prop) && length(sigma_prop) == 1 && n_dim == 1){
       return(matrix(sigma_prop))
     # Otherwise we check for several possible errors
-    } else if (!is.matrix(sigma_prop)){
-      stop("Please provide a square matrix for the sigma_prop parameter.")
-    } else if ((nrow(sigma_prop) != ncol(sigma_prop))){
+    } else if (!is.matrix(sigma_prop) || (nrow(sigma_prop) != ncol(sigma_prop))){
       stop("Please provide a square matrix for the sigma_prop parameter.")
     } else if (n_dim > 1){
       if (nrow(sigma_prop) != n_dim){
@@ -210,8 +208,6 @@
     }
     return(list(FALSE, FALSE, 1, sigma_prop))
   }
-
-
 }
 
 #' Density Plotter

--- a/tests/testthat/test-samplers.R
+++ b/tests/testthat/test-samplers.R
@@ -72,6 +72,10 @@ test_that(".checkSigmaProp", {
   expect_warning(.checkSigmaProp(NULL, 2))
   expect_true(is.matrix(.checkSigmaProp(c(1), 1)))
   expect_no_error(.checkSigmaProp(diag(2), 2))
+  
+  expect_error(.checkSigmaProp(c(0,2,3), 3)) # matrix
+  expect_error(.checkSigmaProp(matrix(0,2,3), 3)) # square matrix
+  expect_error(.checkSigmaProp(diag(2), 3)) # match target distr if mv
 })
 
 test_that(".checkGivenInfo", {


### PR DESCRIPTION
Previously providing the wrong input for sigma_prop parameter in MH or MC3 was not checked for MV distributions - instead throwing an error in CPP. This fixes that, checking that the input is a square matrix of appropiate dimensions