### PR TITLE
Upgrade Bayesian Sampler with expected variance and simulation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -45,6 +45,7 @@ Suggests:
     magrittr,
     mvtnorm,
     xml2,
+    withr,
     samplrData
 LinkingTo: 
   Rcpp, 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # samplr 1.1.0
 * ABS now can return estimates when using relative stopping rule.
 * The Bayesian Sampler function can now be used to not only return expected predictions but also expected variance
-8 The Bayesian Sampler function can be now be used to return simulated predictions.
+* The Bayesian Sampler function can be now be used to return simulated predictions.
 
 # samplr 1.0.1
 * Fixes float comparisons using `!=` and thus not passing tests in some OS.  

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # samplr 1.1.0
 * ABS now can return estimates when using relative stopping rule.
+* The Bayesian Sampler function can now be used to not only return expected predictions but also expected variance
+8 The Bayesian Sampler function can be now be used to return simulated predictions.
 
 # samplr 1.0.1
 * Fixes float comparisons using `!=` and thus not passing tests in some OS.  

--- a/R/Z_identities.R
+++ b/R/Z_identities.R
@@ -200,8 +200,9 @@ get_true_probabilities <- function(
 #' @param beta Prior parameter.
 #' @param N Number of samples drawn
 #' @param N2 Optional. Number of samples drawn for conjunctions and disjunctions. (called N' in the paper). If not given, it will default to N2=N. Must be equal or smaller than N. 
-#'
-#' @return Named list with predicted probabilities for every possible combination of A and B. 
+#' @param return Optional. Either "mean", "variance" or "simulation". 
+
+#' @return If return="mean" or return="variance", named list with predicted probabilities for every possible combination of A and B, or the expected variance of those predictions. If return="simulation", simulated predictions instead. 
 #' @export
 #'
 #' @examples
@@ -220,7 +221,8 @@ Bayesian_Sampler <- function(
     b_and_not_a,
     a_and_not_b,
     not_a_and_not_b,
-    beta, N, N2=NULL){
+    beta, N, N2=NULL, 
+    return="mean"){
   
   if (sd(
     lengths(

--- a/R/Z_identities.R
+++ b/R/Z_identities.R
@@ -252,14 +252,17 @@ Bayesian_Sampler <- function(
     a_and_not_b, 
     not_a_and_not_b
   )
+  get_mean <- function(p, N, beta){
+    p*N/(N+2*beta)+beta/(N+2*beta)
+  }
   predicted_means <- list()
   for (name in names(true_probabilities)){
       if (name %in% c( # treat conjunctions differently
         "b_or_not_a", "not_a_or_not_b", "a_or_b", "a_or_not_b", 
         "a_and_b", "b_and_not_a", "a_and_not_b", "not_a_and_not_b")){
-        predicted_means[[name]] <- true_probabilities[[name]]*N2/(N2+2*beta)+beta/(N2+2*beta)
+        predicted_means[[name]] <- get_mean(true_probabilities[[name]], N2, beta)
       } else{
-        predicted_means[[name]] <- true_probabilities[[name]]*N/(N+2*beta)+beta/(N+2*beta)
+        predicted_means[[name]] <- get_mean(true_probabilities[[name]], N, beta)
       }
   }
   return(predicted_means)

--- a/R/Z_identities.R
+++ b/R/Z_identities.R
@@ -222,7 +222,9 @@ Bayesian_Sampler <- function(
     a_and_not_b,
     not_a_and_not_b,
     beta, N, N2=NULL, 
-    return="mean"){
+    return="mean", 
+    n_simulations = 1e3
+  ){
   
   if (sd(
     lengths(
@@ -260,7 +262,18 @@ Bayesian_Sampler <- function(
   get_v <- function(p, N, beta){
     (N * p * (1-p)) / ((N + 2 * beta)**2)
   }
-  f <- if (return == "mean") get_mean else if (return == "variance") get_v
+  simulate <- function(p, N, beta){
+    (rbinom(n = n_simulations, size = N, prob = p) + beta) / (N + 2 * beta)
+  }
+  f <- if (return == "mean") {
+    get_mean
+  } else if (return == "variance") {
+    get_v
+  } else if (return == "simulation") {
+    simulate
+  } else {
+    stop("return parameter should be one of 'mean', 'variance' or 'simulation'.")
+  }
   return_list <- list()
   for (name in names(true_probabilities)){
       if (name %in% c( # treat conjunctions differently

--- a/R/Z_identities.R
+++ b/R/Z_identities.R
@@ -200,7 +200,8 @@ get_true_probabilities <- function(
 #' @param beta Prior parameter.
 #' @param N Number of samples drawn
 #' @param N2 Optional. Number of samples drawn for conjunctions and disjunctions. (called N' in the paper). If not given, it will default to N2=N. Must be equal or smaller than N. 
-#' @param return Optional. Either "mean", "variance" or "simulation". 
+#' @param return Optional. Either "mean", "variance" or "simulation". Defaults to "mean".
+#' @param n_simulations Optional. if return="simulation", how many simulations per possible combination of A and B. Defaults to 1000.
 
 #' @return If return="mean" or return="variance", named list with predicted probabilities for every possible combination of A and B, or the expected variance of those predictions. If return="simulation", simulated predictions instead. 
 #' @export

--- a/R/Z_identities.R
+++ b/R/Z_identities.R
@@ -264,7 +264,7 @@ Bayesian_Sampler <- function(
     (N * p * (1-p)) / ((N + 2 * beta)**2)
   }
   simulate <- function(p, N, beta){
-    (rbinom(n = n_simulations, size = N, prob = p) + beta) / (N + 2 * beta)
+    (stats::rbinom(n = n_simulations, size = N, prob = p) + beta) / (N + 2 * beta)
   }
   f <- if (return == "mean") {
     get_mean

--- a/R/Z_identities.R
+++ b/R/Z_identities.R
@@ -261,17 +261,17 @@ Bayesian_Sampler <- function(
     (N * p * (1-p)) / ((N + 2 * beta)**2)
   }
   f <- if (return == "mean") get_mean else if (return == "variance") get_v
-  predicted_means <- list()
+  return_list <- list()
   for (name in names(true_probabilities)){
       if (name %in% c( # treat conjunctions differently
         "b_or_not_a", "not_a_or_not_b", "a_or_b", "a_or_not_b", 
         "a_and_b", "b_and_not_a", "a_and_not_b", "not_a_and_not_b")){
-        predicted_means[[name]] <- f(true_probabilities[[name]], N2, beta)
+        return_list[[name]] <- f(true_probabilities[[name]], N2, beta)
       } else{
-        predicted_means[[name]] <- f(true_probabilities[[name]], N, beta)
+        return_list[[name]] <- f(true_probabilities[[name]], N, beta)
       }
   }
-  return(predicted_means)
+  return(return_list)
 }
 
 #' Mean Variance Estimates

--- a/R/Z_identities.R
+++ b/R/Z_identities.R
@@ -257,14 +257,18 @@ Bayesian_Sampler <- function(
   get_mean <- function(p, N, beta){
     p*N/(N+2*beta)+beta/(N+2*beta)
   }
+  get_v <- function(p, N, beta){
+    (N * p * (1-p)) / ((N + 2 * beta)**2)
+  }
+  f <- if (return == "mean") get_mean else if (return == "variance") get_v
   predicted_means <- list()
   for (name in names(true_probabilities)){
       if (name %in% c( # treat conjunctions differently
         "b_or_not_a", "not_a_or_not_b", "a_or_b", "a_or_not_b", 
         "a_and_b", "b_and_not_a", "a_and_not_b", "not_a_and_not_b")){
-        predicted_means[[name]] <- get_mean(true_probabilities[[name]], N2, beta)
+        predicted_means[[name]] <- f(true_probabilities[[name]], N2, beta)
       } else{
-        predicted_means[[name]] <- get_mean(true_probabilities[[name]], N, beta)
+        predicted_means[[name]] <- f(true_probabilities[[name]], N, beta)
       }
   }
   return(predicted_means)

--- a/man/Bayesian_Sampler.Rd
+++ b/man/Bayesian_Sampler.Rd
@@ -11,7 +11,9 @@ Bayesian_Sampler(
   not_a_and_not_b,
   beta,
   N,
-  N2 = NULL
+  N2 = NULL,
+  return = "mean",
+  n_simulations = 1000
 )
 }
 \arguments{
@@ -22,9 +24,13 @@ Bayesian_Sampler(
 \item{N}{Number of samples drawn}
 
 \item{N2}{Optional. Number of samples drawn for conjunctions and disjunctions. (called N' in the paper). If not given, it will default to N2=N. Must be equal or smaller than N.}
+
+\item{return}{Optional. Either "mean", "variance" or "simulation". Defaults to "mean".}
+
+\item{n_simulations}{Optional. if return="simulation", how many simulations per possible combination of A and B. Defaults to 1000.}
 }
 \value{
-Named list with predicted probabilities for every possible combination of A and B.
+If return="mean" or return="variance", named list with predicted probabilities for every possible combination of A and B, or the expected variance of those predictions. If return="simulation", simulated predictions instead.
 }
 \description{
 As described in \insertCite{zhu2020BayesianSamplerGeneric}{samplr}. Vectors can be provided for each parameter, allowing multiple estimates at once.

--- a/tests/testthat/test-Z_identities.R
+++ b/tests/testthat/test-Z_identities.R
@@ -69,6 +69,12 @@ test_that("Bayesian Sampler", {
     beta = 2, 
     N = 200
   )
+  # Test Values
+  expect_equal(
+    unlist(res1, use.names = F), 
+    c(unlist(probs, use.names = F)*20/(20+2*2)+2/(20+2*2))
+  )
+  
   # more samples = closer to true -- 
   expect_true(  abs(sum(unlist(res1[1:4])) - 1) > abs(sum(unlist(res2[1:4])) - 1))
   

--- a/tests/testthat/test-Z_identities.R
+++ b/tests/testthat/test-Z_identities.R
@@ -101,7 +101,7 @@ test_that("Bayesian Sampler", {
   expect_equal(
     res4$a,
     withr::with_seed(123, lapply(probs, \(x){
-      (rbinom(n = 100, size = 20, prob = x) + 2) / (20 + 2 * 2)}
+      (stats::rbinom(n = 100, size = 20, prob = x) + 2) / (20 + 2 * 2)}
       )$a)
   )
   # more samples = closer to true -- 

--- a/tests/testthat/test-Z_identities.R
+++ b/tests/testthat/test-Z_identities.R
@@ -69,6 +69,16 @@ test_that("Bayesian Sampler", {
     beta = 2, 
     N = 200
   )
+  res3 <- Bayesian_Sampler(
+    a_and_b=probs$a_and_b,
+    b_and_not_a = probs$b_and_not_a, 
+    a_and_not_b = probs$a_and_not_b, 
+    not_a_and_not_b = probs$not_a_and_not_b,
+    beta = 2, 
+    N = 20, 
+    return="variance"
+  )
+  res4 <- withr::with_seed(123, Bayesian_Sampler(
   # Test Values
   expect_equal(
     unlist(res1, use.names = F), 
@@ -76,16 +86,7 @@ test_that("Bayesian Sampler", {
   )
   # Test Variance
   expect_equal(
-    unlist(
-      Bayesian_Sampler(
-        a_and_b=probs$a_and_b,
-        b_and_not_a = probs$b_and_not_a, 
-        a_and_not_b = probs$a_and_not_b, 
-        not_a_and_not_b = probs$not_a_and_not_b,
-        beta = 2, 
-        N = 20, 
-      return="variance"
-    ), use.names = F),
+    unlist(res3, use.names = F),
     (20 * unlist(probs, use.names=F) * (1-unlist(probs, use.names=F))) / ((20 + 2 * 2)**2)
   )
   # more samples = closer to true -- 

--- a/tests/testthat/test-Z_identities.R
+++ b/tests/testthat/test-Z_identities.R
@@ -79,6 +79,14 @@ test_that("Bayesian Sampler", {
     return="variance"
   )
   res4 <- withr::with_seed(123, Bayesian_Sampler(
+    a_and_b=probs$a_and_b,
+    b_and_not_a = probs$b_and_not_a, 
+    a_and_not_b = probs$a_and_not_b, 
+    not_a_and_not_b = probs$not_a_and_not_b,
+    beta = 2, 
+    N = 20, 
+    return="simulation", n_simulations = 100
+  ))
   # Test Values
   expect_equal(
     unlist(res1, use.names = F), 
@@ -88,6 +96,13 @@ test_that("Bayesian Sampler", {
   expect_equal(
     unlist(res3, use.names = F),
     (20 * unlist(probs, use.names=F) * (1-unlist(probs, use.names=F))) / ((20 + 2 * 2)**2)
+  )
+  # Test Simulation 
+  expect_equal(
+    res4$a,
+    withr::with_seed(123, lapply(probs, \(x){
+      (rbinom(n = 100, size = 20, prob = x) + 2) / (20 + 2 * 2)}
+      )$a)
   )
   # more samples = closer to true -- 
   expect_true(  abs(sum(unlist(res1[1:4])) - 1) > abs(sum(unlist(res2[1:4])) - 1))

--- a/tests/testthat/test-Z_identities.R
+++ b/tests/testthat/test-Z_identities.R
@@ -175,7 +175,17 @@ test_that("Bayesian Sampler", {
       N = 200
     )
   )
-  
+  # return is not correct
+  expect_error(
+    Bayesian_Sampler(
+      a_and_b=probs$a_and_b,
+      b_and_not_a = probs$b_and_not_a, 
+      a_and_not_b = probs$a_and_not_b, 
+      not_a_and_not_b = probs$not_a_and_not_b,
+      beta = 2, 
+      N = 200, return = "alksdj"
+    )
+  )
   # You can do multiple trials in one call
   res <- matrix(unlist(  Bayesian_Sampler(
     a_and_b=rep(probs$a_and_b, 2),

--- a/tests/testthat/test-Z_identities.R
+++ b/tests/testthat/test-Z_identities.R
@@ -74,7 +74,20 @@ test_that("Bayesian Sampler", {
     unlist(res1, use.names = F), 
     c(unlist(probs, use.names = F)*20/(20+2*2)+2/(20+2*2))
   )
-  
+  # Test Variance
+  expect_equal(
+    unlist(
+      Bayesian_Sampler(
+        a_and_b=probs$a_and_b,
+        b_and_not_a = probs$b_and_not_a, 
+        a_and_not_b = probs$a_and_not_b, 
+        not_a_and_not_b = probs$not_a_and_not_b,
+        beta = 2, 
+        N = 20, 
+      return="variance"
+    ), use.names = F),
+    (20 * unlist(probs, use.names=F) * (1-unlist(probs, use.names=F))) / ((20 + 2 * 2)**2)
+  )
   # more samples = closer to true -- 
   expect_true(  abs(sum(unlist(res1[1:4])) - 1) > abs(sum(unlist(res2[1:4])) - 1))
   


### PR DESCRIPTION
Adds a `return` parameter to the Bayesian Sampler function, which can take three possible values. 
- When return='mean', the function returns the expected prediction (this was the behaviour until now). 
- If return='variance', the function returns the expected variance instead. 
- If return='simulation', the function simulates values instead of giving the expectation. A second new parameter, `n_simulations`, controls how many simulations to carry out.