### PR TITLE
Add names to outputs of calc_PSD

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 * ABS now can return estimates when using relative stopping rule.
 * The Bayesian Sampler function can now be used to not only return expected predictions but also expected variance
 * The Bayesian Sampler function can be now be used to return simulated predictions.
+* `calc_PSD` now returns a named vector in `$polyfit`, so users know what's the intercept and what's the slope
 
 # samplr 1.0.1
 * Fixes float comparisons using `!=` and thus not passing tests in some OS.  

--- a/R/calc_functions.R
+++ b/R/calc_functions.R
@@ -218,6 +218,7 @@ calc_PSD <- function(chain, plot = FALSE){
          main="Power Spectral Density", xlab=x_lbl, ylab=y_lbl,sub=caption)
     abline(Fit[2], Fit[1], col="blue", lwd=2)
   } 
+  names(Fit) <- c("slope", "intercept")
   return(list(
     log_freq = lf,
     log_psd = lpsd,

--- a/tests/testthat/test-calc_functions.R
+++ b/tests/testthat/test-calc_functions.R
@@ -66,7 +66,7 @@ test_that("PSD", {
   expect_equal(names(res), c("log_freq", "log_psd", "polyfit"))
 
   # Check results
-  expect_equal(res[["polyfit"]], c(0.5096142, 2.4102135))
+  expect_equal(res[["polyfit"]], c("slope"=0.5096142, "intercept"=2.4102135))
   vdiffr::expect_doppelganger("PSD Plot", \(){calc_PSD(sequence, T)})
 })
 


### PR DESCRIPTION
The `polyfit` output of `calc_PSD()` now has names for the slope and intercept (hoping to reduce confusion!)